### PR TITLE
Fixes a link to Cms\Models\MaintenanceSetting

### DIFF
--- a/console/Maint.php
+++ b/console/Maint.php
@@ -3,7 +3,7 @@
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
-use Cms\Models\MaintenanceSettings;
+use Cms\Models\MaintenanceSetting;
 
 class Maint extends Command
 {
@@ -24,16 +24,16 @@ class Maint extends Command
     public function fire()
     {
 	$command = implode(' ', (array) $this->argument('name'));
-	$status = MaintenanceSettings::get('is_enabled');
+	$status = MaintenanceSetting::get('is_enabled');
 	if ($command === 'false' && $status == true) {
-		MaintenanceSettings::set('is_enabled', false);
+		MaintenanceSetting::set('is_enabled', false);
 		$this->output->writeln("Maintenance mode is now disabled.");
 	} elseif ($command === 'false' && $status == false) {
 		$this->error("October CMS is already out of Maintenance Mode.");
 	} elseif ($command === 'true' && $status == true) {
 		$this->error("October CMS is already in Maintenance Mode.");
 	} elseif ($command === 'true' && $status == false) {
-		MaintenanceSettings::set('is_enabled', true);
+		MaintenanceSetting::set('is_enabled', true);
 		$this->output->writeln("Maintenance mode is now enabled.");
 	} else {
 		$this->error("Something was wrong with your input. Should look like ./artisan october:maint true or ./artisan october:maint false.");


### PR DESCRIPTION
The path Cms\Models\MaintenanceSettings will throw an error in the latest version of OctoberCMS.