### PR TITLE
Update to work with Laravel 5.5

### DIFF
--- a/console/Maint.php
+++ b/console/Maint.php
@@ -21,7 +21,7 @@ class Maint extends Command
      * Execute the console command.
      * @return void
      */
-    public function fire()
+    public function handle()
     {
 	$command = implode(' ', (array) $this->argument('name'));
 	$status = MaintenanceSetting::get('is_enabled');


### PR DESCRIPTION
With the update to Laravel 5.5, the ...\console\Maint::fire function should be updated to ...\console\Maint::handle.